### PR TITLE
experiments with Property

### DIFF
--- a/example/readProperties.jl
+++ b/example/readProperties.jl
@@ -7,17 +7,4 @@ fileName = String("data\\chemsep1.xml")
 
 dbRoot = getDBRoot(fileName)
 
-# example of extracting first level properties
-ID = extractColumn(dbRoot, "CompoundID")
-
-# example of extracting end level properties
-eqnNo = extractColumn(dbRoot, "LiquidDensity/eqno")
-A = extractColumn(dbRoot, "LiquidDensity/A")
-
-# example of extracing property that is not the last attribute in the xml node (e.g. 1st attribute)
-nameZ = extractColumn(dbRoot, "LiquidDensity", 1)
-
-# get a dataframe with component properties, note this is still in progress, needs to be error checked and corrected for deeper structure hierarchies
-df = getPropertyDataFrame(fileName)
-# write out to CSV
-CSV.write("example\\output.csv", df)
+compound = PhysProps.parse_compound(firstelement(dbRoot)) #returns a Dict

--- a/src/PhysProps.jl
+++ b/src/PhysProps.jl
@@ -6,8 +6,11 @@ using DataFrames
 export
     # read from database, could decide to not export these at later point
       getDBRoot,
-      extractColumn,
-      getPropertyDataFrame
+      name,
+      value,
+      units,
+      parse_compound,
+      parse_property
 
 include("readDB.jl")
 include("purecompbase.jl")
@@ -15,3 +18,4 @@ include("propsbase.jl")
 include("properties.jl")
 
 end # module
+

--- a/src/propsbase.jl
+++ b/src/propsbase.jl
@@ -1,97 +1,269 @@
-# Non-exposed functions that will be used by the wrapper functions
-# TODO: Check these for typos!
+#the strategy is the following:
+#== UnivariateFunction is a type hierarchy do dispatch on functions with ranges.
+it's tighly coupled with the VariableProperty struct.
+Calling a variable property will return a result depending on the type of UnivariateFunction
+This gives the advantage to decouple the use of a dict in each call of a property.
+==#
+abstract type UnivariateFunction end
+struct ConstantEq <: UnivariateFunction end
+struct LinearEq <: UnivariateFunction end
+struct CuadraticEq <: UnivariateFunction end
+struct CubicPolyEq <: UnivariateFunction end
+struct EqNo5 <: UnivariateFunction end
+struct EqNo6 <: UnivariateFunction end
+struct AntoineEq <: UnivariateFunction end
+struct Poly4Eq <: UnivariateFunction end
+struct DIPPREq <: UnivariateFunction end
+struct EqNo102 <: UnivariateFunction end
+struct EqNo103 <: UnivariateFunction end
+struct EqNo104 <: UnivariateFunction end
+struct EqNo105 <: UnivariateFunction end
+struct EqNo106 <: UnivariateFunction end
+struct EqNo107 <: UnivariateFunction end
+struct EqNo114 <: UnivariateFunction end
+struct EqNo117 <: UnivariateFunction end
 
-function f2(T, p...)
-    return p[1] + p[2]*T
+struct EqNo11 <: UnivariateFunction end
+struct EqNo12 <: UnivariateFunction end
+struct EqNo13 <: UnivariateFunction end
+struct EqNo14 <: UnivariateFunction end
+struct EqNo15 <: UnivariateFunction end
+struct EqNo16 <: UnivariateFunction end
+struct EqNo17 <: UnivariateFunction end
+struct EqNo18 <: UnivariateFunction end
+struct EqNo19 <: UnivariateFunction end
+struct EqNo45 <: UnivariateFunction end
+struct EqNo75 <: UnivariateFunction end
+struct EqNo118 <: UnivariateFunction end
+struct EqNo120 <: UnivariateFunction end
+struct EqNo121 <: UnivariateFunction end
+struct EqNo122 <: UnivariateFunction end
+struct EqNo123 <: UnivariateFunction end
+struct EqNo124 <: UnivariateFunction end
+struct EqNo125 <: UnivariateFunction end
+struct EqNo130 <: UnivariateFunction end
+struct EqNo131 <: UnivariateFunction end
+struct EqNo150 <: UnivariateFunction end
+struct EqNo200 <: UnivariateFunction end
+struct EqNo201 <: UnivariateFunction end
+struct EqNo206 <: UnivariateFunction end
+struct EqNo207 <: UnivariateFunction end
+struct EqNo208 <: UnivariateFunction end
+struct EqNo209 <: UnivariateFunction end
+struct EqNo210 <: UnivariateFunction end
+struct EqNo211 <: UnivariateFunction end
+struct EqNo212 <: UnivariateFunction end
+struct EqNo213 <: UnivariateFunction end
+struct EqNo221 <: UnivariateFunction end
+struct EqNo230 <: UnivariateFunction end
+struct EqNo231 <: UnivariateFunction end
+#== 
+_EqNo transforms a number to the appropiate UnivariateFunction Type
+This is basically the Dict, but at compile time.
+Some names are used, to make the VariableProperty Struct more readable.
+==#
+_EqNo(x::Int) = _EqNo(Val(x))
+_EqNo(x::Val{1}) =  ConstantEq() #there was a value 1, that i can interpret as a constant.
+_EqNo(x::Val{2}) =  LinearEq()
+_EqNo(x::Val{3}) =  CuadraticEq()
+_EqNo(x::Val{4}) =  CubicPolyEq()
+_EqNo(x::Val{5}) =  EqNo5()
+_EqNo(x::Val{6}) =  EqNo6()
+_EqNo(x::Val{10}) = AntoineEq()
+_EqNo(x::Val{100}) = Poly4Eq()
+_EqNo(x::Val{101}) = DIPPREq()
+_EqNo(x::Val{102}) = EqNo102()
+_EqNo(x::Val{103}) = EqNo103()
+_EqNo(x::Val{104}) = EqNo104()
+_EqNo(x::Val{105}) = EqNo105()
+_EqNo(x::Val{106}) = EqNo106()
+_EqNo(x::Val{107}) = EqNo107()
+_EqNo(x::Val{114}) = EqNo114()
+_EqNo(x::Val{117}) = EqNo117()
+
+_EqNo(x::Val{11}) = EqNo11()
+_EqNo(x::Val{12}) = EqNo12()
+_EqNo(x::Val{13}) = EqNo13()
+_EqNo(x::Val{14}) = EqNo14()
+_EqNo(x::Val{15}) = EqNo15()
+_EqNo(x::Val{16}) = EqNo16()
+_EqNo(x::Val{17}) = EqNo17()
+_EqNo(x::Val{18}) = EqNo18()
+_EqNo(x::Val{19}) = EqNo19()
+_EqNo(x::Val{45}) = EqNo45()
+_EqNo(x::Val{75}) = EqNo75()
+_EqNo(x::Val{118}) = EqNo118()
+_EqNo(x::Val{120}) = EqNo120()
+_EqNo(x::Val{121}) = EqNo121()
+_EqNo(x::Val{122}) = EqNo122()
+_EqNo(x::Val{123}) = EqNo123()
+_EqNo(x::Val{124}) = EqNo124()
+_EqNo(x::Val{125}) = EqNo125()
+_EqNo(x::Val{130}) = EqNo130()
+_EqNo(x::Val{131}) = EqNo131()
+_EqNo(x::Val{150}) = EqNo150()
+_EqNo(x::Val{200}) = EqNo200()
+_EqNo(x::Val{201}) = EqNo201()
+_EqNo(x::Val{206}) = EqNo206()
+_EqNo(x::Val{207}) = EqNo207()
+_EqNo(x::Val{208}) = EqNo208()
+_EqNo(x::Val{209}) = EqNo209()
+_EqNo(x::Val{210}) = EqNo210()
+_EqNo(x::Val{211}) = EqNo211()
+_EqNo(x::Val{212}) = EqNo212()
+_EqNo(x::Val{213}) = EqNo213()
+_EqNo(x::Val{221}) = EqNo221()
+_EqNo(x::Val{230}) = EqNo230()
+_EqNo(x::Val{231}) = EqNo231()
+#max_length is used to check if some function hasn't enough parameters.
+max_length(x :: T) where T<:UnivariateFunction= 0
+max_length(x::ConstantEq) = 1
+max_length(x::LinearEq) = 2
+max_length(x::CuadraticEq) = 3
+max_length(x::CubicPolyEq) = 4
+max_length(x::AntoineEq) = 3
+max_length(x::Poly4Eq) = 5
+max_length(x::DIPPREq) = 5
+max_length(x::EqNo102) = 4
+max_length(x::EqNo103) = 4
+max_length(x::EqNo104) = 5
+max_length(x::EqNo105) = 4
+max_length(x::EqNo106) = 5
+max_length(x::EqNo107) = 5
+max_length(x::EqNo114) = 4
+max_length(x::EqNo117) = 5
+
+
+#struct to hold the variable property,can hold parameters, or Tc where necessary.
+#with those types, its is fully stack-allocated. if passed to a thermodynamic routine,
+#the evaluation will be fast.
+struct VariableProperty{F <: UnivariateFunction ,T <: Real,N}
+    f::F
+    p::NTuple{N,T}
+    valid_range::NTuple{2,T}
+end 
+
+#Variable property constructor.
+#it does some analisis in some cases, where a function is used, but all parameters are zero,
+#efectively making that function constant.
+function VariableProperty(eqno::Int,p,valid_range) where _FF <: UnivariateFunction
+    _T = promote_type(eltype(p),eltype(valid_range))
+    p0 = first(p)
+    p_nonzero = filter(!iszero,[i for i in p])
+    _F = ConstantEq()
+    _N = 0
+    #check if property is just a constant,then apply constant function (f1)
+    if (length(p_nonzero) == 1) && p0 == first(p_nonzero) && (eqno != 1) && (eqno in (2,3,4,100,103,104,107))
+        _F = ConstantEq()
+        _N = 1
+    else
+        _F = _EqNo(eqno)
+        _N = length(p)
+    end
+
+    #check if length of respective type is correct
+    if max_length(_F) > length(p)
+        throw(ArgumentError("not enough parameters for $eqno property"))
+    end
+    P = NTuple{_N,_T}(convert(_T,i) for i in p)
+    R = NTuple{2,_T}(convert(_T,i) for i in valid_range)
+return VariableProperty{typeof(_F),_T,_N}(_F,P,R)
 end
 
-function f3(T, p...)
-    return p[1] + p[2]*T + p[3]*T^2
+#@inline f11(T,p) = p[1] p[2] p[3] p[4] p[5]
+@inline (prop::EqNo11)(T,p) = exp(p[1])
+@inline (prop::EqNo12)(T,p) = exp(p[1]+p[2]*T)
+@inline (prop::EqNo13)(T,p) = exp(p[1]+p[2]*T+p[3]*T^2)
+@inline (prop::EqNo14)(T,p) = exp(p[1]+p[2]*T+p[3]*T^2+p[4]*T^3)
+@inline (prop::EqNo15)(T,p) = exp(p[1]+p[2]*T+p[3]*T^2+p[4]*T^3+p[5]*T^4)
+@inline (prop::EqNo16)(T,p) = p[1] + exp(p[2]/T + p[3] + p[4]*T +p[5]*T^2)
+@inline (prop::EqNo17)(T,p) = p[1] + exp(p[2] + p[3]*T + p[4]*T^2 +p[5]*T^3)
+@inline (prop::EqNo18)(T,p) = p[1] + p[2]*(1+log(T)*(1+p[3]/T))*exp(-p[3]/T)
+@inline (prop::EqNo19)(T,p) = p[1] + p[2]*T*log(T)*exp(-p[3]/T)
+@inline (prop::EqNo45)(T,p) = p[1]*T + (p[2]*T^2)/2 + (p[3]*T^3)/3 + (p[4]*T^4)/4 + (p[5]*T^5)/5
+@inline (prop::EqNo75)(T,p) = p[2]*(2*p[3]*T + 3*p[4]*T^2 + 4*p[5]*T^3) #weird too, check
+@inline (prop::EqNo118)(T,p) = exp(p[1] + p[2]/(T^p[5]) + p[3]*log(T) + p[4]*T^2) #weird too check
+@inline (prop::EqNo120)(T,p) = p[1] - p[2]/(p[3] + T) #LogAntoine
+@inline (prop::EqNo121)(T,p) =  p[1] + p[2]/T + p[3]*log(T) + p[4]*T^p[5]
+@inline (prop::EqNo122)(T,p) =  p[1] + p[2]/T + p[3]*log(T) + p[4]*T^2 + p[5]/(T^2)
+@inline (prop::EqNo123)(T,p) =  p[1] + p[2]/T + p[3]*T + p[4]*T^2 + p[5]*(T^3)
+@inline (prop::EqNo124)(T,p) =  p[1] + p[2]/T + p[3]/(T^2) + p[4]*T + p[5]*(T^2)
+@inline (prop::EqNo125)(T,p) =  exp(p[1] + p[2]/T + p[3]/(T^2) + p[4]*T + p[5]*(T^2))
+@inline (prop::EqNo130)(T,p) =  exp(p[1] + p[2]/T + p[3]*log(T) + p[4]*T + p[5]/(T^2))
+@inline (prop::EqNo131)(T,p) =  p[1] + p[2]*T + p[3]/(T-p[4])
+@inline (prop::EqNo150)(T,p) = p[1]+p[2]*T+p[3]*T^2+p[4]*T^3 + p[5]/(T^2)
+
+@inline function (prop::EqNo200)(Tr,p) 
+    t = 1-Tr
+    return p[5]*exp((p[1]*t + p[2]*t^1.5 + p[3]*t^2.5 + p[4]*t^5)/Tr)
 end
 
-function f4(T, p...)
-    return p[1] + p[2]*T + p[3]*T^2 + p[4]*T^3
+@inline function (prop::EqNo201)(Tr,p) 
+    t = 1-Tr
+    return p[5]+ exp((p[1]*t + p[2]*t^1.5 + p[3]*t^2.5 + p[4]*t^5)/Tr)
 end
 
-function f5(T, p...)
-    return p[1] + p[2]*T + p[3]*T^2 + p[4]*T^3 + p[5]*T^4
+@inline function (prop::EqNo206)(Tr,p) 
+    t =Tr
+    return p[5]+ exp(p[1]+p[2]/(p[3]+t+p[4]*t^2 + p[5]*t^3))
+end
+@inline (prop::EqNo207)(T,p) = exp(p[1] - p[2]/(p[3] + T))
+@inline (prop::EqNo208)(T,p) = exp10(p[1] - p[2]/(p[3] + T))
+@inline (prop::EqNo209)(T,p) = exp10(p[1]*(1/T - 1/p[2]))
+@inline (prop::EqNo210)(T,p) = exp10(p[1] + p[2]/T + p[3]*T + p[4]*T^2)
+@inline (prop::EqNo211)(T,p) = p[1]*((p[2]-T)/(p[2]-p[3]))^p[4]
+@inline function (prop::EqNo212)(T,p) 
+    a = (1-T/p[5])
+    pol = p[1]*a + p[2]*a^1.5 + p[3]*a^3 + p[4]^6
+    return exp((p[5]*T)*pol)
 end
 
-function f6(T, p...)
-    return p[1] + p[2]*T + p[3]*T^2 + p[4]*T^3 + p[5]/T^2
+@inline function (prop::EqNo213)(T,p) 
+    t = T - 1
+    pol = 1 + p[3]*t + p[4]*t^2 + p[5]*t^3
+    return (p[1]-p[2])/pol
+end
+@inline (prop::EqNo221)(T,p) = -p[2]/(T^2) + p[3]/T + p[4]*p[5]*T^(p[5]-1) 
+@inline (prop::EqNo230)(T,p) = -p[2]/(T^2) + p[3]/T + p[4] - 2*p[5]/T^3 
+@inline (prop::EqNo231)(T,p) = p[2] - p[3]/(T-p[4])^2
+#functor,calling the property like a function.
+#==as these function calls are cheap,
+the function returns for now the value and a bool indicating if thats a valid range.
+an alternative would be adding a keyword to allow the evaluation of the property outside the range 
+==#
+@inline function (prop::VariableProperty)(T)
+    low,high = prop.valid_range
+    if low <= T <= high
+        return prop.f(T,prop.p),true
+    else
+        return prop.f(T,prop.p),false
+    end
 end
 
-function f10(T, p...)
-    return exp(p[1] - p[2]/(p[3] + T))
-end
-
-function f100(T, p...)
-    return p[1] + p[2]*T + p[3]*T^2 + p[4]*T^3 + p[5]*T^4
-end
-
-function f101(T, p...)
-    return exp(p[1] + p[2]/T + p[3]*ln(T) + p[4]*T^p[5])
-end
-
-function f102(T, p...)
-    return p[1]*T^p[2]/(1 + p[3]/T + p[4]/T^2)
-end
-
-function f103(T, p...)
-    return p[1] + p[2]*exp(-p[3]/(T^p[4]))
-end
-
-function f104(T, p...)
-    return p[1] + p[2]/T + 1E6*p[3]/T^3 + 1E16*p[4]/T^8 + 1E18*p[5]/T^9
-end
-
-function f105(T, p...)
-    return p[1]/(p[2]^(1 + (1 - T/p[3])^p[4]))
-end
-
-# Note that Tr is passed, rather than T
-# Sticking to passing the value directly, rather than passing
-# both T and Tc allows a more general calculation.
-# This needs to be handled somewhere...
-# TODO: Make a list of properties using eq 106! Handle in wrapper functions
-function f106(Tr, p...)
-    return p[1]*(1-Tr)^(p[2]+p[3]*Tr+p[4]*Tr^2+p[5]*Tr^3)
-end
-
-function f107(T, p...)
-    return p[1] + p[2]*((p[3]/T)/sinh(p[3]/T))^2 + p[5]*((p[4]/T)*cosh(p[4]/t))^2
-end
-
-function f114(T, p...)
-    return p[1]*T + p[2]*T^2/2 + p[3]*T^3/3 + p[4]*T^4/4
-end
-
-function f117(T, p...)
-    return p[1]*T + p[2]*(p[3]/T)/tanh(p[3]/T) - p[4]*(p[5]/T)/tanh(p[5]/T)
-end
-
-# Look-up dictionary to call the right function from a stored EqNo property
-tfuncs = Dict(
-    2   => f2,
-    3   => f3,
-    4   => f4,
-    5   => f5,
-    6   => f6,
-    10  => f10,
-    100 => f100,
-    101 => f101,
-    102 => f102,
-    103 => f103,
-    104 => f104,
-    105 => f105,
-    106 => f106,
-    107 => f107,
-    114 => f114,
-    117 => f117
-)
+#dispatch to call the f functions from UnivariateFunction.
+#technically you can write the implementation right here
+@inline (prop::ConstantEq)(T,p) = p[1]
+@inline (prop::LinearEq)(T,p) = p[1] + p[2]*T
+@inline (prop::CuadraticEq)(T,p) = p[1] + p[2]*T + p[3]*T^2
+@inline (prop::CubicPolyEq)(T,p) =  p[1] + p[2]*T + p[3]*T^2 + p[4]*T^3
+@inline (prop::EqNo5)(T,p) = p[1] + p[2]*T + p[3]*T^2 + p[4]*T^3 + p[5]*T^4
+@inline (prop::EqNo6)(T,p) =  p[1] + p[2]*T + p[3]*T^2 + p[4]*T^3 + p[5]/T^2
+@inline (prop::AntoineEq)(T,p) =  exp(p[1] - p[2]/(p[3] + T))
+@inline (prop::Poly4Eq)(T,p)  =  p[1] + p[2]*T + p[3]*T^2 + p[4]*T^3 + p[5]*T^4
+@inline (prop::DIPPREq)(T,p) =  exp(p[1] + p[2]/T + p[3]*log(T) + p[4]*T^p[5])
+@inline (prop::EqNo102)(T,p) =  p[1]*T^p[2]/(1 + p[3]/T + p[4]/T^2)
+@inline (prop::EqNo103)(T,p) =  p[1] + p[2]*exp(-p[3]/(T^p[4]))
+@inline (prop::EqNo104)(T,p) =   p[1] + p[2]/T + 1E6*p[3]/T^3 + 1E16*p[4]/T^8 + 1E18*p[5]/T^9
+@inline (prop::EqNo105)(T,p) =  p[1]/(p[2]^(1 + (1 - T/p[3])^p[4]))
+@inline (prop::EqNo106)(Tr,p) = p[1]*(1-Tr)^(p[2]+p[3]*Tr+p[4]*Tr^2+p[5]*Tr^3)
+@inline (prop::EqNo107)(T,p) =  p[1] + p[2]*((p[3]/T)/sinh(p[3]/T))^2 + p[5]*((p[4]/T)*cosh(p[4]/T))^2
+@inline (prop::EqNo114)(T,p) =  p[1]*T + p[2]*T^2/2 + p[3]*T^3/3 + p[4]*T^4/4
+@inline (prop::EqNo117)(T,p) =  p[1]*T + p[2]*(p[3]/T)/tanh(p[3]/T) - p[4]*(p[5]/T)/tanh(p[5]/T)
 
 # Generic function to call the right temperature dependency
-function calcvectorproperty(T, prop::VectorProperty)
-    tfunc = tfuncs[prop.EqNo]
-    tfunc(T, prop.A, prop.B, prop.C, prop.D, prop.E)
-end
+#function calcvectorproperty(T, prop::VectorProperty)
+#    tfunc = tfuncs[prop.EqNo]
+#    tfunc(T, prop.A, prop.B, prop.C, prop.D, prop.E)
+#end
+
+

--- a/src/purecompbase.jl
+++ b/src/purecompbase.jl
@@ -25,3 +25,80 @@ end
 value(prop::Property) = prop.value
 name(prop::Property) = prop.name
 units(prop::Property) = prop.units
+
+
+#those structs are no longer used in this branch.
+struct ScalarProperty
+    units::String
+    value::Float64
+end
+
+struct RangeBoundary
+    units::String
+    value::Float64
+end
+
+struct VectorProperty
+    units::String
+    EqNo::Int
+    A::Float64
+    B::Float64
+    C::Float64
+    D::Float64
+    E::Float64
+    Tmin::RangeBoundary
+    Tmax::RangeBoundary
+end
+
+struct PureComp
+    LibraryIndex::Int
+    CompoundID::String
+    StructureFormula::String
+    Family::Int
+    CriticalTemperature::ScalarProperty
+    CriticalPressure::ScalarProperty
+    CriticalVolume::ScalarProperty
+    CriticalComperssibility::ScalarProperty
+    NormalBoilingPointTemperature::ScalarProperty
+    NormalMeltingPointTemperature::ScalarProperty
+    TripplePointTemperature::ScalarProperty
+    TripplePointPressure::ScalarProperty
+    MolecularWeight::ScalarProperty
+    LiquidVolumeAtNormalBoilingPoint::ScalarProperty
+    AcentricityFactor::ScalarProperty
+    SolubilityParameter::ScalarProperty
+    DipoleMoment::ScalarProperty
+    HeatOfFormation::ScalarProperty
+    GibbsEnergyOfFormation::ScalarProperty
+    AbsEntropy::ScalarProperty
+    HeatOfFusionAtMeltingPoint::ScalarProperty
+    HeatOfCombustion::ScalarProperty
+    LiquidDensity::VectorProperty
+    VaporPressure::VectorProperty
+    HeatOfVaporization::VectorProperty
+    LiquidHeatCapacityCp::VectorProperty
+    IdealHeatCapacityCp::VectorProperty
+    SecondVirialCoefficient::VectorProperty
+    LiquidViscosity::VectorProperty
+    VaporViscosity::VectorProperty
+    LiquidThermalConductivity::VectorProperty
+    VaporThermalConductivity::VectorProperty
+    RPPHeatCapacityCp::VectorProperty
+    RelativeStaticPermittivity::VectorProperty
+    AntoineVaporPressure::VectorProperty
+    LiquidViscosityRPS::VectorProperty
+    COSTALDVolume::ScalarProperty
+    DiameterLJ::ScalarProperty
+    EnergyLJ::ScalarProperty
+    RacketParameter::ScalarProperty
+    FullerVolume::ScalarProperty
+    Parachor::ScalarProperty
+    SpecificGravity::ScalarProperty
+    Charge::ScalarProperty
+    CostaldAcentricFactor::ScalarProperty
+    WilsonVolume::ScalarProperty
+    ChaoSeaderAcentricFactor::ScalarProperty
+    ChaoSeaderSolubilityParameter::ScalarProperty
+    ChaoSeaderLiquidVolume::ScalarProperty
+    CAS::String
+end

--- a/src/purecompbase.jl
+++ b/src/purecompbase.jl
@@ -1,87 +1,27 @@
-# LibraryIndex, CompoundID
-struct IntVal
-    name::String
-    value::Int
+#GroupContribution Struct.
+#it statically stores the id and values.
+struct GroupContribution{N}
+    id::NTuple{N,Int}
+    value::NTuple{N,Int}
 end
 
-struct StringVal
-    name::String
-    value::String
-end
+#==
+Property Struct:
+it holds a value and its metadata.
+for now, the metadata is the long name and the units.
+the property is parametrically typed on the value, to recognize if is a 
+string, Int, Float, VariableProperty, or GroupContribution. 
+it can replace IntVal, StringVal, 
+TODO:in the future, using Unitful to hold the value, something like:
+Property{T,UNITS} where UNITS <: Unitful.Unit
+==#
 
-struct ScalarProperty
-    name::String
-    units::String
-    value::Float64
-end
-
-struct RangeBoundary
-    units::String
-    value::Float64
-end
-
-struct VectorProperty
+struct Property{T}
     name::String
     units::String
-    EqNo::Int
-    A::Float64
-    B::Float64
-    C::Float64
-    D::Float64
-    E::Float64
-    Tmin::RangeBoundary
-    Tmax::RangeBoundary
+    value::T
 end
 
-struct PureComp
-    LibraryIndex::IntVal
-    CompoundID::IntVal
-    StructureFormula::StringVal
-    Family::IntVal
-    CriticalTemperature::ScalarProperty
-    CriticalPressure::ScalarProperty
-    CriticalVolume::ScalarProperty
-    CriticalComperssibility::ScalarProperty
-    NormalBoilingPointTemperature::ScalarProperty
-    NormalMeltingPointTemperature::ScalarProperty
-    TripplePointTemperature::ScalarProperty
-    TripplePointPressure::ScalarProperty
-    MolecularWeight::ScalarProperty
-    LiquidVolumeAtNormalBoilingPoint::ScalarProperty
-    AcentricityFactor::ScalarProperty
-    SolubilityParameter::ScalarProperty
-    DipoleMoment::ScalarProperty
-    HeatOfFormation::ScalarProperty
-    GibbsEnergyOfFormation::ScalarProperty
-    AbsEntropy::ScalarProperty
-    HeatOfFusionAtMeltingPoint::ScalarProperty
-    HeatOfCombustion::ScalarProperty
-    LiquidDensity::VectorProperty
-    VaporPressure::VectorProperty
-    HeatOfVaporization::VectorProperty
-    LiquidHeatCapacityCp::VectorProperty
-    IdealHeatCapacityCp::VectorProperty
-    SecondVirialCoefficient::VectorProperty
-    LiquidViscosity::VectorProperty
-    VaporViscosity::VectorProperty
-    LiquidThermalConductivity::VectorProperty
-    VaporThermalConductivity::VectorProperty
-    RPPHeatCapacityCp::VectorProperty
-    RelativeStaticPermittivity::VectorProperty
-    AntoineVaporPressure::VectorProperty
-    LiquidViscosityRPS::VectorProperty
-    COSTALDVolume::ScalarProperty
-    DiameterLJ::ScalarProperty
-    EnergyLJ::ScalarProperty
-    RacketParameter::ScalarProperty
-    FullerVolume::ScalarProperty
-    Parachor::ScalarProperty
-    SpecificGravity::ScalarProperty
-    Charge::ScalarProperty
-    CostaldAcentricFactor::ScalarProperty
-    WilsonVolume::ScalarProperty
-    ChaoSeaderAcentricFactor::ScalarProperty
-    ChaoSeaderSolubilityParameter::ScalarProperty
-    ChaoSeaderLiquidVolume::ScalarProperty
-    CAS::StringVal
-end
+value(prop::Property) = prop.value
+name(prop::Property) = prop.name
+units(prop::Property) = prop.units

--- a/src/readDB.jl
+++ b/src/readDB.jl
@@ -19,7 +19,7 @@ This function corrects the type from String to Int64 or Float64.
 """
 function extractColumn(dbRoot::EzXML.Node, propName::String, n::Int64 = 0)
 
-    temp = EzXML.attributes.(findall(
+    temp = EzXML.EzXML.attributes.(findall(
         "//compounds/compound/" * propName,
         dbRoot,
     ))::Array{Array{EzXML.Node,1},1}
@@ -62,4 +62,77 @@ function getPropertyDataFrame(fileName::String)::DataFrame # this function is no
     end
 
     return df
+end
+
+
+"""
+_parse_property(compound_node)
+
+parse a property and returns the proper struct from the ChemSep XML
+"""
+function parse_property(property)
+    identifier = Symbol(property.name) #Symbol of the property name
+    elems = length(EzXML.elements(property))
+    if iszero(elems) #is value, float, int or String
+        data = EzXML.attributes(property)
+        name = data[1].content
+        raw_value = data[end].content
+        if length(data) == 3 #property is a float number
+            units =  data[2].content
+            value = parse(Float64,raw_value)
+            return identifier,Property(name,units,value)
+        elseif length(data) == 2 #value is String or Int
+            if name in ("Index","Family") #only ints 
+                value = parse(Int,raw_value)
+                return identifier,Property(name,"_",value)
+            else 
+                return identifier,Property(name,"_",raw_value)
+            end
+        end
+    elseif EzXML.firstelement(property).name == "eqno" #Variable Property
+        data = EzXML.attributes(property)
+        valuedata = EzXML.elements(property)
+        len = length(valuedata)
+        name = data[1].content
+        units = data[2].content
+        eqno = parse(Int,attributes(valuedata[1])[1].content)
+        parameters = [parse(Float64,attributes(valuedata[i])[1].content) for i in 2:(len-2)]
+        valid_range = [parse(Float64,attributes(valuedata[i])[2].content) for i in (len-1):len]
+        value = VariableProperty(eqno,parameters,valid_range)
+        return identifier,Property(name,units,value)
+    elseif EzXML.firstelement(property).name == "group" #GroupContribution
+        data = EzXML.attributes(property)
+        name = data[1].content
+        groups = EzXML.elements(property)
+        len = length(groups)
+        id_vector = Int[]
+        value_vector = Int[]
+        for group in groups
+            raw_id,raw_value = EzXML.attributes(group)
+            push!(id_vector,parse(Int,raw_id))
+            push!(value_vector,parse(Int,raw_value))
+        end
+        _id = NTuple{len,Int}(id_vector)
+        _value = NTuple{len,Int}(value_vector)
+        value = GroupContribution{len}(_id,_value)
+        return identifier,Property(name,"_",value)
+    end
+end
+
+
+    """
+    parse_compound(compound_node)
+    
+    parses the XML of a compound node. returns a Dict{Symbol,Property}
+    
+    """
+function parse_compound(compound)
+    symbols = Symbol[]
+    properties = Property[]
+    for property in EzXML.eachelement(compound)
+        name, prop = parse_property(property)
+        push!(symbols,name)
+        push!(properties,prop)
+    end 
+    return comp = Dict{Symbol,Property}((i,j) for (i,j) in zip(symbols,properties))   
 end

--- a/src/readDB.jl
+++ b/src/readDB.jl
@@ -1,8 +1,5 @@
-# functions for accessing db from chemsep .xml
-
 """
     getDBRoot(fileName)
-
 Get root node of .xml database
 """
 function getDBRoot(fileName::String)::EzXML.Node
@@ -13,13 +10,12 @@ end
 
 """
     extractColumn(dbRoot, propName, n=0)
-
 Extract a column of data providing the root node, and the property name as described in the .xml file. To access deeper levels use '/' e.g. "LiquidDensity/eqno"
 This function corrects the type from String to Int64 or Float64.
 """
 function extractColumn(dbRoot::EzXML.Node, propName::String, n::Int64 = 0)
 
-    temp = EzXML.EzXML.attributes.(findall(
+    temp = EzXML.attributes.(findall(
         "//compounds/compound/" * propName,
         dbRoot,
     ))::Array{Array{EzXML.Node,1},1}
@@ -42,7 +38,6 @@ end
 
 """
     getPropertyDataFrame(fileName)
-
 Return a DataFrame containing component properties for a given filename
 """
 function getPropertyDataFrame(fileName::String)::DataFrame # this function is not complete, still in progress
@@ -58,12 +53,195 @@ function getPropertyDataFrame(fileName::String)::DataFrame # this function is no
 
     for name in columnNames
         data = extractColumn(dbRoot, name)
-        (length(data) == lengthID) && (df[:, Symbol(name)] = data)
+        (length(data) == lengthID) && (df[!, Symbol(name)] = data)
     end
 
     return df
 end
 
+@inline getScalar(props, propnum) = ScalarProperty(props[propnum]["units"], parse(Float64, props[propnum]["value"]))
+
+function getVector(props, propnum)
+    units = props[propnum]["units"]
+    eqno =  parse(Int, EzXML.elements(props[propnum])[1]["value"])
+
+    A_ = EzXML.findfirst("A", props[propnum])
+    A = isnothing(A_) ? 0.0 : parse(Float64, A_["value"])
+    B_ = EzXML.findfirst("B", props[propnum])
+    B = isnothing(B_) ? 0.0 : parse(Float64, B_["value"])
+    C_ = EzXML.findfirst("C", props[propnum])
+    C = isnothing(C_) ? 0.0 : parse(Float64, C_["value"])
+    D_ = EzXML.findfirst("D", props[propnum])
+    D = isnothing(D_) ? 0.0 : parse(Float64, D_["value"])
+    E_ = EzXML.findfirst("E", props[propnum])
+    E = isnothing(E_) ? 0.0 : parse(Float64, E_["value"])
+
+    Tmin_ = EzXML.findfirst("Tmin", props[propnum])
+    Tmin = RangeBoundary(Tmin_["units"], parse(Float64, Tmin_["value"]))
+    Tmax_ = EzXML.findfirst("Tmax", props[propnum])
+    Tmax = RangeBoundary(Tmax_["units"], parse(Float64, Tmax_["value"]))
+
+    return VectorProperty(units, eqno, A, B, C, D, E, Tmin, Tmax)
+end
+
+function extractComp(dbRoot, idx)
+    tmp = EzXML.findfirst("//compounds/compound[" * string(idx) *"]", dbRoot)
+    props = nodes(tmp)
+
+    # LibraryIndex::Int
+    libidx = parse(Int, props[2]["value"])
+    # CompoundID::String
+    cmpid = props[4]["value"]
+    # StructureFormula::String
+    struture = props[6]["value"]
+    # Family::Int
+    family = parse(Int, props[8]["value"])
+    # CriticalTemperature::ScalarProperty
+    Tc = getScalar(props, 10)
+    # CriticalPressure::ScalarProperty
+    Pc = getScalar(props, 12)
+    # CriticalVolume::ScalarProperty
+    Vc = getScalar(props, 14)
+    # CriticalComperssibility::ScalarProperty
+    Zc = getScalar(props, 16)
+    # NormalBoilingPointTemperature::ScalarProperty
+    Tb = getScalar(props, 18)
+    # NormalMeltingPointTemperature::ScalarProperty
+    Tf = getScalar(props, 20)
+    # TripplePointTemperature::ScalarProperty
+    T3 = getScalar(props, 22)
+    # TripplePointPressure::ScalarProperty
+    P3 = getScalar(props, 24)
+    # MolecularWeight::ScalarProperty
+    MW = getScalar(props, 26)
+    # LiquidVolumeAtNormalBoilingPoint::ScalarProperty
+    Vb = getScalar(props, 28)
+    # AcentricityFactor::ScalarProperty
+    omega = getScalar(props, 30)
+    # SolubilityParameter::ScalarProperty
+    lambda = getScalar(props, 32)
+    # DipoleMoment::ScalarProperty
+    mu = getScalar(props, 34)
+    # HeatOfFormation::ScalarProperty
+    hf = getScalar(props, 36)
+    # GibbsEnergyOfFormation::ScalarProperty
+    gf = getScalar(props, 38)
+    # AbsEntropy::ScalarProperty
+    sabs = getScalar(props, 40)
+    # HeatOfFusionAtMeltingPoint::ScalarProperty
+    hff = getScalar(props, 42)
+    # HeatOfCombustion::ScalarProperty
+    hc = getScalar(props, 44)
+    # LiquidDensity::VectorProperty
+    rhol = getVector(props, 46)
+    # VaporPressure::VectorProperty
+    Psat = getVector(props, 48)
+    # HeatOfVaporization::VectorProperty
+    hvap = getVector(props, 50)
+    # LiquidHeatCapacityCp::VectorProperty
+    cpliq = getVector(props, 52)
+    # IdealHeatCapacityCp::VectorProperty
+    cpig = getVector(props, 54)
+    # SecondVirialCoefficient::VectorProperty
+    virB = getVector(props, 56)
+    # LiquidViscosity::VectorProperty
+    muL = getVector(props, 58)
+    # VaporViscosity::VectorProperty
+    muV = getVector(props, 60)
+    # LiquidThermalConductivity::VectorProperty
+    kL = getVector(props, 62)
+    # VaporThermalConductivity::VectorProperty
+    kV = getVector(props, 64)
+    # RPPHeatCapacityCp::VectorProperty
+    cpRPP = getVector(props, 66)
+    # RelativeStaticPermittivity::VectorProperty
+    epsRel = getVector(props, 68)
+    # AntoineVaporPressure::VectorProperty
+    PAnt = getVector(props, 70)
+    # LiquidViscosityRPS::VectorProperty
+    muRPS = getVector(props, 72)
+    # COSTALDVolume::ScalarProperty
+    VCost = getScalar(props, 74)
+    # DiameterLJ::ScalarProperty
+    sigLJ = getScalar(props, 76)
+    # EnergyLJ::ScalarProperty
+    eLJ = getScalar(props, 78)
+    # RacketParameter::ScalarProperty
+    ZRa = getScalar(props, 80)
+    # FullerVolume::ScalarProperty
+    VFuller = getScalar(props, 82)
+    # Parachor::ScalarProperty
+    par = getScalar(props, 84)
+    # SpecificGravity::ScalarProperty
+    SG = getScalar(props, 86)
+    # Charge::ScalarProperty
+    charge = getScalar(props, 88)
+    # CostaldAcentricFactor::ScalarProperty
+    omegaCost = getScalar(props, 90)
+    # WilsonVolume::ScalarProperty
+    VWils = getScalar(props, 92)
+    # ChaoSeaderAcentricFactor::ScalarProperty
+    OmegaCS = getScalar(props, 94)
+    # ChaoSeaderSolubilityParameter::ScalarProperty
+    lambdaCS = getScalar(props, 96)
+    # ChaoSeaderLiquidVolume::ScalarProperty
+    VCS = getScalar(props, 98)
+    # CAS::StringVal
+    CAS = props[100]["value"]
+
+    return PureComp(
+        libidx,
+        cmpid,
+        struture,
+        family,
+        Tc,
+        Pc,
+        Vc,
+        Zc,
+        Tb,
+        Tf,
+        T3,
+        P3,
+        MW,
+        Vb,
+        omega,
+        lambda,
+        mu,
+        hf,
+        gf,
+        sabs,
+        hff,
+        hc,
+        rhol,
+        Psat,
+        hvap,
+        cpliq,
+        cpig,
+        virB,
+        muL,
+        muV,
+        kL,
+        kV,
+        cpRPP,
+        epsRel,
+        PAnt,
+        muRPS,
+        VCost,
+        sigLJ,
+        eLJ,
+        ZRa,
+        VFuller,
+        par,
+        SG,
+        charge,
+        omegaCost,
+        VWils,
+        OmegaCS,
+        lambdaCS,
+        VCS,
+        CAS
+    )
+end
 
 """
 _parse_property(compound_node)


### PR DESCRIPTION
changes the internal machinery of the function evaluation and compound struct.
the main change: the Compound Struct is now a Dict with properties of type `Property`. I did this because i noted that, because of the group contributions, the fields were of variable length. one option is to use the PureCompound Struct and store the group values in a vector.

group contribution ID are stored in its own struct.
Temperature-dependent properties are stored in a `VariableProperty` struct, with its parameters and range. internaly, the functions are dispatched via UnivariateFunction, this can change, but the big advantage of doing this is that the `VariableProperty`  is completely typed and stack-allocated.

to parse a compound, there is the function `parse_compound`
to parse a property, there is the function `parse_property`

with respect to the equation numbers, there was another table. is was added to allow the parser to properly parse. i added those functions as well.
there are at this moment, 3 helper functions for property: `name`, `units `and `value`, that access to the corresponding property Field.
In the future, a good idea would be to use the existing Unitful package to parse the units, but there are semantic differences that must be resolved first. (for example `Pa.s` in the Viscosity).
